### PR TITLE
Feat: 카카오 소셜 로그인 및 로그아웃 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 const logger = require("morgan");
 
 const indexRouter = require("./routes/index");
+const authRouter = require("./routes/auth");
 
 const app = express();
 
@@ -17,13 +18,13 @@ app.use(cookieParser());
 
 app.use(
   cors({
-    origin: `http://localhost:${process.env.PORT}}`,
+    origin: process.env.CLIENT_PORT,
     methods: "GET, POST",
     credential: true,
-    preflightContinue: true,
   }),
 );
 
 app.use("/", indexRouter);
+app.use("/auth", authRouter);
 
 module.exports = app;

--- a/model/User.js
+++ b/model/User.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose");
+
+const UserSchema = new mongoose.Schema(
+  {
+    nickname: { type: String, trim: true },
+    email: { type: String, required: true, unique: true, trim: true },
+    history: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Package",
+      },
+    ],
+    bookmark: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Order",
+      },
+    ],
+    loginType: {
+      type: String,
+      enum: ["local", "kakao", "google"],
+      required: true,
+    },
+    refresh_token: {
+      id: { type: String },
+      expires: { type: Number },
+    },
+  },
+  { timestamps: true },
+);
+
+const User = mongoose.model("User", UserSchema);
+
+module.exports = { User };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "axios": "^1.7.4",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^16.4.5",
         "express": "~4.16.1",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.5.2",
         "morgan": "~1.9.1",
         "nodemon": "^3.1.4"
@@ -352,6 +354,23 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -426,6 +445,12 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -511,6 +536,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -598,6 +635,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -620,6 +666,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1015,6 +1070,40 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1252,6 +1341,55 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -1297,11 +1435,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -1771,6 +1951,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon ./bin/www",
+    "start": "node ./bin/www",
     "postinstall": "husky install",
     "format": "prettier --cache --write .",
     "lint": "eslint --cache .",

--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
+    "start": "nodemon ./bin/www",
     "postinstall": "husky install",
     "format": "prettier --cache --write .",
     "lint": "eslint --cache .",
     "dev": "NODE_ENV=development nodemon ./bin/www"
   },
   "dependencies": {
+    "axios": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^16.4.5",
     "express": "~4.16.1",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.2",
     "morgan": "~1.9.1",
     "nodemon": "^3.1.4"

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,117 @@
+const express = require("express");
+
+const jwt = require("jsonwebtoken");
+const axios = require("axios");
+const { User } = require("../model/User");
+
+const router = express.Router();
+
+router.post("/sign-in/kakao", async (req, res, next) => {
+  try {
+    const { authCode } = req.body;
+    const {
+      data: {
+        access_token,
+        refresh_token,
+        expires_in,
+        refresh_token_expires_in,
+      },
+    } = await axios.post(
+      "https://kauth.kakao.com/oauth/token",
+      new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: process.env.KAKAO_CLIENT_ID,
+        redirect_uri: process.env.CLIENT_PORT,
+        code: authCode,
+      }),
+      {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+      },
+    );
+
+    const {
+      data: {
+        id: target_id,
+        properties: { nickname },
+        kakao_account: { email },
+      },
+    } = await axios.get("https://kapi.kakao.com/v2/user/me", {
+      headers: {
+        "content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        Authorization: "Bearer " + access_token,
+      },
+    });
+
+    const refresh_token_expires = Date.parse(
+      new Date() + refresh_token_expires_in * 1000,
+    );
+
+    const existUser = await User.findOne({ email }).lean();
+    let _id;
+
+    if (existUser) {
+      await User.updateOne(
+        { email },
+        {
+          refresh_token: {
+            id: refresh_token,
+            expires: refresh_token_expires,
+          },
+        },
+      );
+
+      _id = existUser._id;
+    } else {
+      const userDate = await User.create({
+        nickname,
+        email,
+        loginType: "kakao",
+        refresh_token: {
+          id: refresh_token,
+          expires: refresh_token_expires,
+        },
+      });
+
+      _id = userDate._id;
+    }
+
+    const jwtToken = jwt.sign({ _id }, process.env.JWT_SECRET_KEY, {
+      expiresIn: expires_in,
+    });
+
+    res.send({ jwtToken, refresh_token, _id, target_id });
+  } catch (error) {
+    res.status(500).send(error);
+  }
+});
+
+router.post("/sign-out/kakao", async (req, res, next) => {
+  try {
+    const { target_id } = req.body;
+    const result = await axios.post(
+      "https://kapi.kakao.com/v1/user/logout",
+      new URLSearchParams({
+        target_id_type: "user_id",
+        target_id,
+      }),
+      {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded;charset=utf-8",
+          Authorization: "KakaoAK " + process.env.KAKAO_ADMIN_KEY,
+        },
+      },
+    );
+
+    if (result.data.id) {
+      res.send({ message: "성공적으로 로그아웃 했습니다." });
+    } else {
+      res.send({ message: "로그아웃에 실패했습니다." });
+    }
+  } catch (error) {
+    res.status(500).send(error);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
# 칸반 명

* [[APP] 소셜 로그인 관련 back 로직 구현](https://www.notion.so/startled-hamster/APP-back-f8b2d5e7adc54c668beac029de52a12d?pvs=4)

* [[APP] 소셜 로그아웃 관련 back 로직 구현](https://www.notion.so/startled-hamster/Server-back-262d451d3ddc406e9eb5c957f086dccd?pvs=4)
# 구현화면

# 해당 업무 리스트

- [x] 해당 소셜 인가코드를 받을시 access_token 으로 잘 교환시켜야 합니다. 
- [x] 받은 access_token으로 유저정보와 잘 교환시켜야 합니다.
- [x] 받은 유저정보를 데이터베이스에 잘 저장시킵니다.
- [x] 로그아웃 요청을 받을시 해당 처리 관련 로직을 구현합니다.
- [x] 인증,인가 관련해서 jwt 를 활용해야합니다.

# 상세 기술

- 인가코드를 전달받았을때 access_token 으로 교환 받고 해당 토큰을 이용해서 유저정보를 잘 불러옵니다.
- 추후 refresh_token을 통해 만료 access_token 을 재발급하는데 쓰일 예정입니다.
- 사용자가 카카오 로그인 또는 로그아웃을 했을떄 관련 로직 구현입니다.
- 로그인 했을때 받아온 유저정보를 기반으로 jwt을 발급시켜줍니다.
- Axios, jwt 관련 라이브러리 설치

# 참고사항

- refresh_token 관련 로직을 짜 놓긴 했는데 아직 해당 로직과 관련된 client 구현이 아직이여서 잠시 보류 시켜놓았습니다.
- jwt 인증 관련해서도 로직을 짜 놓았지만 해당 로직과 관련된 client 구현이 아직이여서 잠시 보류 시켜놓았습니다.
- 팀원과 협업을 통한 소셜 로그인 및 로그아웃 구현이여서 나머지 구글, 로컬 관련 로그인은 팀원 commit을 통해 확인하시면 됩니다.
- 카카오 소셜로그인 전체적인 흐름은 인가코드->access_token교환->해당 토큰으로 유저정보 교환 -> 유저정보를 토대로 데이터베이스 저장 -> jwt 토큰 발급해서 클라이언트측 전달

- axios, jwt 관련 라이브러리를 설치했기 때문에 pull 받으신 이후 아래 명령어를 실행해주세요.

```
npm install 
```

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항

-스크립트 명령어 리셋