### PR TITLE
Feat: 수신자 - 일련번호 폼제출을 받은 뒤 매크로 행동 불러오기 back 로직구현

### DIFF
--- a/model/Package.js
+++ b/model/Package.js
@@ -4,6 +4,7 @@ const OrderSchema = new mongoose.Schema(
   {
     action: { type: String, required: true },
     attachmentName: { type: String },
+    attachmentType: { type: String },
     attachmentUrl: { type: String },
     sourcePath: { type: String },
     executionPath: { type: String, required: true },
@@ -14,7 +15,7 @@ const OrderSchema = new mongoose.Schema(
 
 const PackageSchema = new mongoose.Schema(
   {
-    serialNumber: { type: Number },
+    serialNumber: { type: Number, unique: true },
     orders: {
       type: [OrderSchema],
       required: true,
@@ -23,7 +24,10 @@ const PackageSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
     },
-    expireAt: { type: Date, default: new Date(), expires: 600 },
+    expireAt: {
+      type: Date,
+      default: () => new Date(Date.now() + 10 * 60 * 1000),
+    },
   },
   { timestamps: true },
 );

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -43,8 +43,6 @@ router.get("/:serialNumber", async (req, res, next) => {
   const serialNumber = req.params?.serialNumber;
   const existPackage = await Package.findOne({ serialNumber }).lean();
 
-  console.log(existPackage, serialNumber);
-
   if (!existPackage) {
     return res.status(404).json({ message: "찾을 수 없는 주문입니다." });
   }

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -27,7 +27,7 @@ router.post("/new", verifyJWTToken, async (req, res, next) => {
   const newPackage = await Package.create({
     serialNumber,
     orders,
-    author: userId ?? "NotLoginUser",
+    ...(userId && { author: userId }),
   });
 
   if (userId) {
@@ -37,6 +37,22 @@ router.post("/new", verifyJWTToken, async (req, res, next) => {
     );
   }
   res.send({ serialNumber, packageId: newPackage._id });
+});
+
+router.get("/:serialNumber", async (req, res, next) => {
+  const serialNumber = req.params?.serialNumber;
+  const existPackage = await Package.findOne({ serialNumber }).lean();
+
+  console.log(existPackage, serialNumber);
+
+  if (!existPackage) {
+    return res.status(404).json({ message: "찾을 수 없는 주문입니다." });
+  }
+
+  return res.status(200).json({
+    message: "성공적으로 주문을 불러왔습니다.",
+    existPackage,
+  });
 });
 
 module.exports = router;

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -40,17 +40,26 @@ router.post("/new", verifyJWTToken, async (req, res, next) => {
 });
 
 router.get("/:serialNumber", async (req, res, next) => {
-  const serialNumber = req.params?.serialNumber;
-  const existPackage = await Package.findOne({ serialNumber }).lean();
+  try {
+    const serialNumber = req.params?.serialNumber;
+    const existPackage = await Package.findOne({ serialNumber }).lean();
 
-  if (!existPackage) {
-    return res.status(404).json({ message: "찾을 수 없는 주문입니다." });
+    if (!existPackage) {
+      return res.status(404).json({ message: "찾을 수 없는 주문입니다." });
+    }
+
+    return res.status(200).json({
+      message: "성공적으로 주문을 불러왔습니다.",
+      existPackage,
+    });
+  } catch (error) {
+    return res
+      .status(500)
+      .json({
+        message:
+          "일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+      });
   }
-
-  return res.status(200).json({
-    message: "성공적으로 주문을 불러왔습니다.",
-    existPackage,
-  });
 });
 
 module.exports = router;

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -52,13 +52,10 @@ router.get("/:serialNumber", async (req, res, next) => {
       message: "성공적으로 주문을 불러왔습니다.",
       existPackage,
     });
-  } catch (error) {
-    return res
-      .status(500)
-      .json({
-        message:
-          "일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
-      });
+  } catch {
+    return res.status(500).json({
+      message: "일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    });
   }
 });
 


### PR DESCRIPTION
# 칸반 명

* [[APP] 📩 수신자 - 일련번호 폼제출을 받은 뒤: 매크로 행동 불러오기 back 로직 구현](https://www.notion.so/startled-hamster/APP-back-8c12c7ebbbc444b0bad2c9eb19dc4d1a)


# 해당 업무 리스트

- [x]  전달 받은 serial-number(일련번호)로 해당하는 소포가 있는지 데이터베이스(MongoDb)에서 확인합니다.
- [x]  소포가 정상적으로 조회될 경우 orders에 관한 내용을 응답으로 보내줍니다.
- [x]  소포가 없을 경우 에러응답을 돌려보냅니다.


# 상세 기술

- 일련번호 입력 또는 링크를 눌러서 요청이 전송되면 해당 일련번호 또는 링크 id 를 통해 해당 소포 스키마를 찾아서 전송합니다.

# 참고사항
- Express에서 동적 라우터를 사용할 때 경로에 하이픈(-)을 포함하면 경로를 찾지 못하는 문제가 발생했습니다. 이 문제를 해결하기 위해 경로명을 카멜케이스로 변경해 두었습니다. 이후 작업하시는 분들도 참고해 주시기 바랍니다.
```
// 변경전
Get / packages/{serial-number}
```
```
// 변경후
Get / packages/{serialNumber}
```

# PR 체크 사항

## 주의 사항

- [x]  PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x]  conflict를 모두 해결하고 PR을 올려주세요.

## PR 전 체크리스트

- [x]  가장 최신 브랜치를 pull 하였습니다.
- [x]  base 브랜치명을 확인하였습니다.
- [x]  코드 컨벤션을 모두 확인하였습니다.
- [x]  브랜치명을 확인하였습니다.
- [x]  작업 중 dependency 변경사항이 있는 경우 안내해주세요!

---

## 리뷰 반영사항
- 